### PR TITLE
[DO NOT MERGE] route by rcinfo type

### DIFF
--- a/config/log.js
+++ b/config/log.js
@@ -50,7 +50,27 @@ var config = {
                   },
     		          pause: 1000,
                   payload: '{ "this": { "is": "a JSON object" }, "int": 1234 }'
-          }
+          },
+          { 
+                  rcinfo: {
+    			  type: 'API',
+    			  method: 'POST',
+			  url: 'http://some.api/post',
+			  port: 1234,
+			  headers: {
+                            'Content-Type': 'application/json'
+                          }
+    		    },
+    		    pause: 0,
+            	    payload: {
+				  "streams": [
+				    {
+				      "labels": "{foo=\"bar\"}",
+				      "entries": [{ "ts": "2018-12-18T08:28:06.801064-04:00", "line": "baz" }]
+				    }
+				  ]
+			      }
+            }
       ]
 };
 

--- a/config/log.js
+++ b/config/log.js
@@ -65,8 +65,8 @@ var config = {
             	    payload: {
 				  "streams": [
 				    {
-				      "labels": "{foo=\"bar\"}",
-				      "entries": [{ "ts": "2018-12-18T08:28:06.801064-04:00", "line": "baz" }]
+				      "labels": "{type=\"json\"}",
+				      "entries": [{ "ts": new Date().toISOString(), "line": "This is a cool log with Call-ID: "+call_id }]
 				    }
 				  ]
 			      }

--- a/hepgen.js
+++ b/hepgen.js
@@ -63,10 +63,9 @@ var sendHEP3 = function(msg,rcinfo){
 
 var sendAPI = function(msg,rcinfo){
 	/* 	not yet implemented. 
-		push data to API using methods in rcinfo for POST/GET, URL, etc. msg must be JSON.	
-	*/
-	
-	/*
+		PUSH non-HEP data to API using methods in rcinfo for Query parameters.	
+		The following MESSAGE format is proposed:
+
 		    rcinfo: {
     			  type: 'API',
     			  method: 'POST',
@@ -77,8 +76,17 @@ var sendAPI = function(msg,rcinfo){
                           }
     		    },
     		    pause: 0,
-            	    payload: { "this": "could be anything", count: 0 }
-        }
+            	    payload: 	{
+				  "streams": [
+				    {
+				      "labels": "{foo=\"bar\"}",
+				      "entries": [{ "ts": "2018-12-18T08:28:06.801064-04:00", "line": "baz" }]
+				    }
+				  ]
+				}
+        	     }
+	
+	
 	*/
 }
 

--- a/hepgen.js
+++ b/hepgen.js
@@ -62,13 +62,19 @@ var sendHEP3 = function(msg,rcinfo){
 }
 
 var sendAPI = function(msg,rcinfo){
-	/* not implemented. push data to API using methods in rcinfo for POST/GET, URL, etc. msg must be JSON.	*/
+	/* 	not yet implemented. 
+		push data to API using methods in rcinfo for POST/GET, URL, etc. msg must be JSON.	
+	*/
+	
 	/*
 		    rcinfo: {
     			  type: 'API',
     			  method: 'POST',
 			  url: 'http://some.api/post',
-			  other: 1234
+			  port: 1234,
+			  headers: {
+                            'Content-Type': 'application/json'
+                          }
     		    },
     		    pause: 0,
             	    payload: { "this": "could be anything", count: 0 }

--- a/hepgen.js
+++ b/hepgen.js
@@ -34,6 +34,16 @@ var getSocket = function (type) {
 var socket = dgram.createSocket("udp4");
     socket = getSocket('udp4'); 
 
+var countDown = function(){
+	count--;
+	if (count == 0) {
+		if(socket) socket.close();
+		console.log(stats);
+		console.log('Done! Exiting...');
+		process.exit(0);
+	}	
+}
+
 var sendHEP3 = function(msg,rcinfo){
 	if (rcinfo) {
 		try {
@@ -43,13 +53,7 @@ var sendHEP3 = function(msg,rcinfo){
 			if (hep_message) {
 				socket.send(hep_message, 0, hep_message.length, _config_.HEP_PORT, _config_.HEP_SERVER, function(err) {
 					stats.hepsent++;
-					count--;
-					if (count == 0) {
-				  	   socket.close();
-				  	   console.log(stats);
-				  	   console.log('Done! Exiting...');
-					     process.exit(0);
-					}
+					countDown();
 				});
 			} else { console.log('HEP Parsing error!'); stats.heperr++; }
 		}
@@ -63,30 +67,7 @@ var sendHEP3 = function(msg,rcinfo){
 
 var sendAPI = function(msg,rcinfo){
 	/* 	PUSH non-HEP data to API using methods in rcinfo for Query parameters.	
-		The following MESSAGE format is proposed:
-
-		    rcinfo: {
-    			  type: 'API',
-    			  method: 'POST',
-			  hostname: 'http://some.api',
-			  path: '/post',
-			  port: 1234,
-			  headers: {
-                            'Content-Type': 'application/json'
-                          }
-    		    },
-    		    pause: 0,
-            	    payload: 	{
-				  "streams": [
-				    {
-				      "labels": "{foo=\"bar\"}",
-				      "entries": [{ "ts": "2018-12-18T08:28:06.801064-04:00", "line": "baz" }]
-				    }
-				  ]
-				}
-        	     }
-	
-	
+		For an example API message format, see config/log.js
 	*/
 	const http = require('http')
 	const options = {
@@ -103,6 +84,7 @@ var sendAPI = function(msg,rcinfo){
 	const req = http.request(options, (res) => {
 	  console.log(`API statusCode: ${res.statusCode}`)
 	  stats.hepsent++;
+	  countDown();
 	  res.on('data', (d) => {
 	    process.stdout.write(d)
 	  })

--- a/hepgen.js
+++ b/hepgen.js
@@ -61,6 +61,32 @@ var sendHEP3 = function(msg,rcinfo){
 	}
 }
 
+var sendAPI = function(msg,rcinfo){
+	/* not implemented. push data to API using methods in rcinfo for POST/GET, URL, etc. msg must be JSON.	*/
+	/*
+		    rcinfo: {
+    			  type: 'API',
+    			  method: 'POST',
+			  url: 'http://some.api/post',
+			  other: 1234
+    		    },
+    		    pause: 0,
+            	    payload: { "this": "could be anything", count: 0 }
+        }
+	*/
+}
+
+var routeOUT = function(msg,rcinfo){
+  console.log('ROUTING',msg,rcinfo);
+	if (rcinfo.type === "HEP"){
+		sendHEP3(msg,rcinfo);
+	} else if(rcinfo.type === "API") {		
+		sendAPI(msg,rcinfo);
+	} else {
+		console.error('Unsupported Type!',rcinfo);	
+	}
+};
+
 function sleep(ms) {
   var start = new Date().getTime(), expire = start + ms;
   while (new Date().getTime() < expire) { }
@@ -73,7 +99,7 @@ var pause = 0;
 const execHEP = function(messages) {
   count = messages.length;
   messages.forEach(function preHep(message) {
-
+	  
 	var rcinfo = message.rcinfo;
 	var msg = message.payload;
 	if (debug) console.log(msg);
@@ -98,11 +124,11 @@ const execHEP = function(messages) {
 	            var datenow = new Date().getTime();
 		    rcinfo.time_sec = Math.floor( datenow / 1000);
 		    rcinfo.time_usec = datenow - (rcinfo.time_sec*1000);
-		    sendHEP3(msg,rcinfo);
+		    routeOUT(msg,rcinfo);
 		    process.stdout.write("rcvd: "+stats.rcvd+", parsed: "+stats.parsed+", hepsent: "+stats.hepsent+", err: "+stats.err+", heperr: "+stats.heperr+"\r");
 		}, pause);
 	} else {
-		sendHEP3(msg,rcinfo);
+		routeOUT(msg,rcinfo);
 		process.stdout.write("rcvd: "+stats.rcvd+", parsed: "+stats.parsed+", hepsent: "+stats.hepsent+", err: "+stats.err+", heperr: "+stats.heperr+"\r");
 	}
   });

--- a/hepgen.js
+++ b/hepgen.js
@@ -62,14 +62,14 @@ var sendHEP3 = function(msg,rcinfo){
 }
 
 var sendAPI = function(msg,rcinfo){
-	/* 	not yet implemented. 
-		PUSH non-HEP data to API using methods in rcinfo for Query parameters.	
+	/* 	PUSH non-HEP data to API using methods in rcinfo for Query parameters.	
 		The following MESSAGE format is proposed:
 
 		    rcinfo: {
     			  type: 'API',
     			  method: 'POST',
-			  url: 'http://some.api/post',
+			  hostname: 'http://some.api',
+			  path: '/post',
 			  port: 1234,
 			  headers: {
                             'Content-Type': 'application/json'
@@ -88,6 +88,33 @@ var sendAPI = function(msg,rcinfo){
 	
 	
 	*/
+	const http = require('http')
+	const options = {
+	  hostname: rcinfo.hostname,
+	  port: rcinfo.port,
+	  path: rcinfo.path,
+	  method: rcinfo.method,
+	  headers: {
+	    'Content-Type': 'application/json',
+	    'Content-Length': msg.length
+	  }
+	}
+
+	const req = http.request(options, (res) => {
+	  console.log(`API statusCode: ${res.statusCode}`)
+	  stats.hepsent++;
+	  res.on('data', (d) => {
+	    process.stdout.write(d)
+	  })
+	})
+
+	req.on('error', (error) => {
+	  console.error(error)
+	  stats.heperr++;
+	})
+	req.write(JSON.stringify(rcinfo.payload));
+	req.end();
+	
 }
 
 var routeOUT = function(msg,rcinfo){


### PR DESCRIPTION
Skeleton to route non-HEP messages to APIs using `rcinfo.type` parameter

##### Example Message type `API`
```javascript
{ 
        rcinfo: {
    		type: 'API',
    		method: 'POST',
		url: 'http://some.api/post',
		port: 1234,
		headers: {
                  'Content-Type': 'application/json'
                }
    	},
    	pause: 0,
        payload: {
	  "streams": [
	    {
		"labels": "{type=\"json\"}",
		"entries": [{ "ts": new Date().toISOString(), "line": "This is a cool log with Call-ID: "+call_id }]
	    }
	  ]
	}
}
```